### PR TITLE
chore: rationalise script names and add more utility scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,11 @@
 * assets: root of tree containing visualiser artwork
   * assets/visualisers/vumeters:  location of VU meter artwork
   * assets/visualisers/spectrum: location of Spectrum meter artwork
-* tcz/scripts/build-vis-meters.sh - core script to build the visualiser tcz files
-* tcz/scripts/pcp_build_tcz.sh - script to build visualiser tcz files on piCorePlayer
 * tcz/suites: path containing tcz suite files which  define the contents of tcz files
+* tcz/scripts/build-all-vis-meter-suites.sh - core script to build all the visualiser suite tcz files
+* tcz/scripts/pcpbuild-all-vis-meter-suites.sh - script to build visualiser suite tcz files on piCorePlayer
+* tcz/scripts/build-vis-meter-suite.sh - script to build a single visualiser suite tcz file
+* tcz/scripts/build-vis-meter.sh - script to build a single visualiser tcz file
 
 ## tcz suite files
 tcz suite files contain lists of meters to include in a single visualiser tcz file.

--- a/tcz/scripts/build-all-vis-meter-suites.sh
+++ b/tcz/scripts/build-all-vis-meter-suites.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+SCRIPT_PATH=$(dirname $(realpath $0))
+BASE_PATH=$(dirname $(dirname ${SCRIPT_PATH}))
+BUILD_PATH="${BASE_PATH}/build"
+LOGS_PATH="${BUILD_PATH}/logs"
+VISUALISERS_PATH="${BASE_PATH}/assets/visualisers"
+SUITES_PATH="${BASE_PATH}/tcz/suites"
+
+function build_tcz_suite {
+    suite_definition="$1"
+    tcz_name=$(basename $1)
+    echo "tcz=$tcz_name"
+    dstdir="${BUILD_PATH}/${tcz_name}/opt/jivelite/assets/visualisers/$2/"
+    rm -rf ${dstdir}
+    mkdir -p ${dstdir}
+    mkdir -p ${LOGS_PATH}
+
+    declare -A info_array
+    info_array["Title:"]="${tcz_name}.tcz"
+    info_array["Description:"]="Community squeezebox controller 3rd party VU image."
+    info_array["Version:"]="8.0.0"
+    info_array["Commit:"]="-"
+    info_array["Author:"]="-"
+    info_array["Original-site:"]="https://forums.lyrion.org"
+    info_array["Copying-policy:"]="Public Domain"
+    info_array["Size:"]="-"
+    info_array["Extension_by:"]="piCorePlayer team: https://www.picoreplayer.org/"
+
+
+    while IFS= read -r line
+    do
+        if [ -d "${VISUALISERS_PATH}/${line}" ] ;
+        then 
+            echo "    adding ${line}"
+            cp -aR "${VISUALISERS_PATH}/${line}" ${dstdir}
+        else
+            meta_key=$(echo "${line}" | awk '{print $1}')
+            meta_value=$(echo "${line}" | sed -e 's/^.*:\s*//')
+            info_array["${meta_key}"]="${meta_value}"
+        fi
+    done < ${suite_definition}
+
+    rm -f "${BUILD_PATH}/${tcz_name}.tcz*"
+    cd ${BUILD_PATH}
+    pwd
+    mksquashfs "${tcz_name}/" "${tcz_name}.tcz" -b 16384 -info >& "${LOGS_PATH}/${tcz_name}.log" && md5sum "${tcz_name}.tcz" > "${tcz_name}.tcz.md5.txt"
+    echo "created ${PWD}/${tcz_name}.tcz"
+    echo "log file is ${PWD}/logs/${tcz_name}.log"
+    cd "${BUILD_PATH}/${tcz_name}"
+    find opt -type f > "${BUILD_PATH}/${tcz_name}.list"
+    cd ${BUILD_PATH} 
+    rm -rf ${tcz_name}
+    echo "BOGUS.tcz" > ${tcz_name}.dep.tcz
+    size=$(ls -l "${tcz_name}.tcz" | awk '{print $5}')
+    info_array["Size:"]="$size"
+    rm -f "${tcz_name}.tcz.info"
+#    for elem in "${!info_array[@]}"
+#    do
+#        echo "${elem}		${info_array[${elem}]}" >> "${tcz_name}.tcz.info"
+#    done
+#
+    for elem in "Title:" "Description:" "Version:" "Commit:" "Author:" "Original-site:" "Copying-policy:" "Size:" "Extension_by:"
+    do
+        echo "${elem}		${info_array[${elem}]}" >> "${tcz_name}.tcz.info"
+    done
+    cd ${SCRIPT_PATH} 
+}
+
+for f in ${SUITES_PATH}/vumeters/*
+do
+    echo "----- $f"
+    if [ -f $f ] ;
+    then
+        build_tcz_suite $f "vumeters"
+    fi
+done
+
+for f in ${SUITES_PATH}/spectrum/*
+do
+    echo "----- $f"
+    if [ -f $f ] ;
+    then
+        build_tcz_suite $f "spectrum"
+    fi
+done

--- a/tcz/scripts/build-vis-meter-suite.sh
+++ b/tcz/scripts/build-vis-meter-suite.sh
@@ -1,5 +1,18 @@
 #!/usr/bin/env bash
 
+if [ -f "$1" ] ; then
+    if [ "$2" == "vumeters" ] || [ "$2" == "spectrum" ] ;
+    then
+        :
+    else
+        echo "Usage $0 <path-to-suitefile> <vumeters|spectrum>"
+        exit 1
+    fi
+else
+    echo "Usage $0 <path-to-suitefile> <vumeters|spectrum>"
+    exit 1
+fi
+
 set -euo pipefail
 SCRIPT_PATH=$(dirname $(realpath $0))
 BASE_PATH=$(dirname $(dirname ${SCRIPT_PATH}))
@@ -8,7 +21,8 @@ LOGS_PATH="${BUILD_PATH}/logs"
 VISUALISERS_PATH="${BASE_PATH}/assets/visualisers"
 SUITES_PATH="${BASE_PATH}/tcz/suites"
 
-function build_tcz {
+function build_tcz_suite {
+    suite_definition="$1"
     tcz_name=$(basename $1)
     echo "tcz=$tcz_name"
     dstdir="${BUILD_PATH}/${tcz_name}/opt/jivelite/assets/visualisers/$2/"
@@ -39,7 +53,7 @@ function build_tcz {
             meta_value=$(echo "${line}" | sed -e 's/^.*:\s*//')
             info_array["${meta_key}"]="${meta_value}"
         fi
-    done < $1
+    done < ${suite_definition}
 
     rm -f "${BUILD_PATH}/${tcz_name}.tcz*"
     cd ${BUILD_PATH}
@@ -67,20 +81,11 @@ function build_tcz {
     cd ${SCRIPT_PATH} 
 }
 
-for f in ${SUITES_PATH}/vumeters/*
-do
-    echo "----- $f"
-    if [ -f $f ] ;
+if [ -f "$1" ] ; then
+    if [ "$2" == "vumeters" ] || [ "$2" == "spectrum" ] ;
     then
-        build_tcz $f "vumeters"
+        build_tcz_suite "$1" "$2"
+    else
+        echo "Usage $0 <spath-to-suitefile> <vumeters|spectrum>"
     fi
-done
-
-for f in ${SUITES_PATH}/spectrum/*
-do
-    echo "----- $f"
-    if [ -f $f ] ;
-    then
-        build_tcz $f "spectrum"
-    fi
-done
+fi

--- a/tcz/scripts/build-vis-meter.sh
+++ b/tcz/scripts/build-vis-meter.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+usage="Usage $0 <path-to-visualiser> <author> <copying-policy>"
+
+if [ -d "$1" ] ; then
+    vistype=$(basename $(dirname "$1"))
+    echo "**** $vistype"
+    if [ "$vistype" == "vumeters" ] || [ "$vistype" == "spectrum" ] ;
+    then
+        if [ "$2" == "" ] || [ "$3" == "" ] ;
+        then
+            echo $usage
+            exit 1
+        fi
+    else
+        echo $usage
+        exit 1
+    fi
+else
+    echo $usage
+    exit 1
+fi
+
+set -euo pipefail
+SCRIPT_PATH=$(dirname $(realpath $0))
+BASE_PATH=$(dirname $(dirname ${SCRIPT_PATH}))
+BUILD_PATH="${BASE_PATH}/build"
+LOGS_PATH="${BUILD_PATH}/logs"
+VISUALISERS_PATH="${BASE_PATH}/assets/visualisers"
+
+    tcz_name=$(basename $1)
+    if [ "$vistype" == "vumeters" ] && [ -f "$1/meta.json" ] ;
+    then
+        tcz_name="VU_Meter_vis_${tcz_name}"
+    elif [ "$vistype" == "spectrum" ] && [ -f "$1/meta.json" ] ;
+    then
+        tcz_name="VU_Meter_vis_${tcz_name}"
+    else
+        echo "missing meta.json file?"
+        exit 2
+    fi
+
+    echo "tcz=$tcz_name"
+    dstdir="${BUILD_PATH}/${tcz_name}/opt/jivelite/assets/visualisers/$2/"
+    rm -rf ${dstdir}
+    mkdir -p ${dstdir}
+    mkdir -p ${LOGS_PATH}
+
+    declare -A info_array
+    info_array["Title:"]="${tcz_name}.tcz"
+    info_array["Description:"]="Community squeezebox controller 3rd party VU image."
+    info_array["Version:"]="8.0.0"
+    info_array["Commit:"]="-"
+    info_array["Author:"]="$2"
+    info_array["Original-site:"]="https://forums.lyrion.org"
+    info_array["Copying-policy:"]="$3"
+    info_array["Size:"]="-"
+    info_array["Extension_by:"]="piCorePlayer team: https://www.picoreplayer.org/"
+
+
+    cp -aR "${1}" ${dstdir}
+
+    rm -f "${BUILD_PATH}/${tcz_name}.tcz*"
+    cd ${BUILD_PATH}
+    pwd
+    mksquashfs "${tcz_name}/" "${tcz_name}.tcz" -b 16384 -info >& "${LOGS_PATH}/${tcz_name}.log" && md5sum "${tcz_name}.tcz" > "${tcz_name}.tcz.md5.txt"
+    echo "created ${PWD}/${tcz_name}.tcz"
+    echo "log file is ${PWD}/logs/${tcz_name}.log"
+    cd "${BUILD_PATH}/${tcz_name}"
+    find opt -type f > "${BUILD_PATH}/${tcz_name}.list"
+    cd ${BUILD_PATH} 
+    rm -rf ${tcz_name}
+    echo "BOGUS.tcz" > ${tcz_name}.dep.tcz
+    size=$(ls -l "${tcz_name}.tcz" | awk '{print $5}')
+    info_array["Size:"]="$size"
+    rm -f "${tcz_name}.tcz.info"
+#    for elem in "${!info_array[@]}"
+#    do
+#        echo "${elem}		${info_array[${elem}]}" >> "${tcz_name}.tcz.info"
+#    done
+#
+    for elem in "Title:" "Description:" "Version:" "Commit:" "Author:" "Original-site:" "Copying-policy:" "Size:" "Extension_by:"
+    do
+        echo "${elem}		${info_array[${elem}]}" >> "${tcz_name}.tcz.info"
+    done
+    cd ${SCRIPT_PATH} 

--- a/tcz/scripts/pcp-build-all-vis-meter-suites.sh
+++ b/tcz/scripts/pcp-build-all-vis-meter-suites.sh
@@ -15,7 +15,7 @@ then
     tce-load -il git
     tce-load -il squashfs-tools
 
-    $SCRIPTDIR/build-vis-meter-suites.sh
+    $SCRIPTDIR/build-all-vis-meter-suites.sh
 else
     echo "This script must be run on piCorePlayer"
 fi


### PR DESCRIPTION
Rename
 - build-vis-meter-suites.sh -> build-all-vis-meter-suites.sh
 - pcp-build-vis-meters.sh -> pcp-build-all-vis-meter-suites.sh so that it is clear they build ALL suites

Add
 - build-vis-meter-suite.sh : builds a single visualiser suite tcz
 - build-vis-meter.sh : build a single visualiser tcz